### PR TITLE
Support rails 4 by only including the observer connection code if Observer is defined

### DIFF
--- a/lib/multi_db/connection_proxy.rb
+++ b/lib/multi_db/connection_proxy.rb
@@ -5,10 +5,10 @@ module MultiDb
     include ActiveRecord::ConnectionAdapters::QueryCache
     include QueryCacheCompat
     extend ThreadLocalAccessors
-    
+
     # Safe methods are those that should either go to the slave ONLY or go
     # to the current active connection.
-    SAFE_METHODS = [ :select_all, :select_one, :select_value, :select_values, 
+    SAFE_METHODS = [ :select_all, :select_one, :select_value, :select_values,
       :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
       :disconnect!, :reset_runtime, :log, :log_info ]
 
@@ -20,13 +20,13 @@ module MultiDb
 
     attr_accessor :master, :config
     tlattr_accessor :master_depth, :current, true
-    
+
     class << self
 
       # defaults to RAILS_ENV if multi_db is used with Rails
       # defaults to 'development' when used outside Rails
       attr_accessor :environment
-      
+
       # a list of models that should always go directly to the master
       #
       # Example:
@@ -39,7 +39,7 @@ module MultiDb
       # has to do this.
       # This will not affect failover if a master is unavailable.
       attr_accessor :sticky_slave
-      
+
       # if master should be the default db
       attr_accessor :defaults_to_master
 
@@ -49,16 +49,16 @@ module MultiDb
         self.master_models ||= DEFAULT_MASTER_MODELS
         self.environment   ||= (defined?(RAILS_ENV) ? RAILS_ENV : 'development')
         self.sticky_slave  ||= false
-        
+
         master = ActiveRecord::Base
         slaves = init_slaves
         raise "No slaves databases defined for environment: #{self.environment}" if slaves.empty?
         master.send :include, MultiDb::ActiveRecordExtensions
-        ActiveRecord::Observer.send :include, MultiDb::ObserverExtensions
+        ActiveRecord::Observer.send :include, MultiDb::ObserverExtensions if ActiveRecord.const_defined?(:Observer)
         master.connection_proxy = new(master, slaves, scheduler)
         master.logger.info("** multi_db with master and #{slaves.length} slave#{"s" if slaves.length > 1} loaded.")
       end
-      
+
       protected
 
       # Slave entries in the database.yml must be named like this
@@ -91,7 +91,7 @@ module MultiDb
       end
 
       private :new
-      
+
     end
 
     def initialize(master, slaves, scheduler = Scheduler)
@@ -112,22 +112,22 @@ module MultiDb
     def slave
       @slaves.current
     end
-    
+
     def scheduler
       @slaves
     end
-    
-    
+
+
     def with_master
       self.current = @master
       self.master_depth += 1
       yield
     ensure
       self.master_depth -= 1
-      self.current = slave if (master_depth <= 0) 
+      self.current = slave if (master_depth <= 0)
     end
-  
-  
+
+
     def with_slave
       self.current = slave
       self.master_depth -= 1
@@ -136,7 +136,7 @@ module MultiDb
       self.master_depth += 1
       self.current = @master if (master_depth > 0)
     end
-    
+
     def transaction(start_db_transaction = true, &block)
       with_master { @master.retrieve_connection.transaction(start_db_transaction, &block) }
     end
@@ -144,7 +144,7 @@ module MultiDb
     # Calls the method on master/slave and dynamically creates a new
     # method on success to speed up subsequent calls
     def method_missing(method, *args, &block)
-      send(target_method(method), method, *args, &block).tap do 
+      send(target_method(method), method, *args, &block).tap do
         create_delegation_method!(method)
       end
     end
@@ -169,18 +169,18 @@ module MultiDb
         end
       }, __FILE__, __LINE__
     end
-    
+
     def target_method(method)
       unsafe?(method) ? :send_to_master : :send_to_current
     end
-    
+
     def send_to_master(method, *args, &block)
       reconnect_master! if @reconnect
       @master.retrieve_connection.send(method, *args, &block)
     rescue => e
       raise_master_error(e)
     end
-    
+
     def send_to_current(method, *args, &block)
       reconnect_master! if @reconnect && master?
       current.retrieve_connection.send(method, *args, &block)
@@ -194,26 +194,26 @@ module MultiDb
       next_reader!
       retry
     end
-    
+
     def reconnect_master!
       @master.retrieve_connection.reconnect!
       @reconnect = false
     end
-    
+
     def raise_master_error(error)
       logger.fatal "[MULTIDB] Error accessing master database. Scheduling reconnect"
       @reconnect = true
       raise error
     end
-    
+
     def unsafe?(method)
       !SAFE_METHODS.include?(method)
     end
-    
+
     def master?
       current == @master
     end
-        
+
     def logger
       ActiveRecord::Base.logger
     end


### PR DESCRIPTION
```
[2] pry(main)> Rails.version
=> "3.2.22.2"
[1] pry(main)> ActiveRecord.const_defined?(:Observer)
=> true
```

```
irb(main):002:0> Rails.version
=> "4.0.13"
irb(main):001:0> ActiveRecord.const_defined?(:Observer)
=> false
```
